### PR TITLE
refactor: 해더 - 애니메이션 적용

### DIFF
--- a/src/compoent/Header/TypingEffext.tsx
+++ b/src/compoent/Header/TypingEffext.tsx
@@ -1,0 +1,59 @@
+import { Box, Text } from "@radix-ui/themes";
+import { useEffect, useState } from "react";
+
+const TypingEffext = ({
+  text = "",
+  typingSpeed = 200,
+  deletingSpeed = 100,
+  delayAfterTyping = 3000,
+}: {
+  text: string;
+  typingSpeed?: number;
+  deletingSpeed?: number;
+  delayAfterTyping?: number;
+}) => {
+  const [displayedText, setDisplayedText] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (!text) return;
+
+    let timeout: ReturnType<typeof setTimeout>;
+
+    if (!isDeleting && index <= text.length) {
+      // 타이핑 중
+      timeout = setTimeout(() => {
+        setDisplayedText(text.slice(0, index));
+        setIndex((prev) => prev + 1);
+      }, typingSpeed);
+    } else if (index > text.length) {
+      // 타이핑 완료
+      timeout = setTimeout(() => {
+        setIsDeleting(true);
+        setIndex((prev) => prev - 1);
+      }, delayAfterTyping);
+    } else if (isDeleting && index >= 0) {
+      // 지우는 중
+      timeout = setTimeout(() => {
+        setDisplayedText(text.slice(0, index));
+        setIndex((prev) => prev - 1);
+      }, deletingSpeed);
+    } else if (index < 0) {
+      // 지우기 완료
+      setIsDeleting(false);
+      setIndex(0);
+    }
+
+    return () => clearInterval(timeout);
+  }, [index, isDeleting, text, typingSpeed, deletingSpeed, delayAfterTyping]);
+
+  return (
+    <Box className="w-[28rem] max-[600px]:w-[100%]" overflow="hidden">
+      <Text as="div" weight="bold" align="center">
+        <span className="theme-text corsur-ani">{displayedText}</span>
+      </Text>
+    </Box>
+  );
+};
+export default TypingEffext;

--- a/src/data/Header.ts
+++ b/src/data/Header.ts
@@ -1,10 +1,9 @@
 export const data: {
-  title: string;
   subTitle1: string;
   subTitle2: string;
 } = {
-  title: "안녕하세요, 저는 프론트엔드 개발자 입니다.",
   subTitle1:
-    "사용자 경험을 중시하며 현대적이고 반응형 웹 애플리케이션을 만드는 것을 좋아합니다.",
-  subTitle2: "React, TypeScript, Next.js를 주로 사용합니다.",
+    "혼자 일할 때는 주도적으로, 함께할 때는 시너지를 만드는 개발자를 목표로 합니다.",
+  subTitle2:
+    "기술을 매개로 함께 배우고 성장하는 것이 제가 추구하는 방향입니다. :)",
 };

--- a/src/page/home/AboutMe.tsx
+++ b/src/page/home/AboutMe.tsx
@@ -29,7 +29,7 @@ const AboutMe = () => {
             ))}
           </Flex>
         </Box>
-        <Flex className="flex-1" direction="column" align={"center"}>
+        {/* <Flex className="flex-1" direction="column" align={"center"}>
           <Box
             className="border-4 border-transparent rounded-full overflow-hidden theme-border"
             width={"16rem"}
@@ -44,7 +44,7 @@ const AboutMe = () => {
               }}
             />
           </Box>
-        </Flex>
+        </Flex> */}
       </Flex>
     </Flex>
   );

--- a/src/page/home/Header.tsx
+++ b/src/page/home/Header.tsx
@@ -1,23 +1,65 @@
-import { Button, Flex, Text } from "@radix-ui/themes";
+import { Box, Button, Flex, Text } from "@radix-ui/themes";
+import TypingEffext from "../../compoent/Header/useTypingEffext";
 import { data } from "../../data/Header";
+import { mediaText } from "../../utils/media";
+
+const ORIGIN_SIZE = 60;
+const MOBILE_SIZE = 40;
 
 const Header = () => {
   return (
-    <Flex className="container" direction="column" align={"center"} py={"9"}>
-      <Text as="div" size={"9"} weight={"bold"} mb={"4"} align="center">
-        안녕하세요, 저는 <span className="theme-text">프론트엔드 개발자</span>{" "}
-        입니다.
-      </Text>
-      <Text as="div" size="5" color="gray" align="center" weight={"medium"}>
-        {data.subTitle1}
-      </Text>
-      <Text as="div" size="5" color="gray" align="center" weight={"medium"}>
-        {data.subTitle2}
-      </Text>
-      <Button className="bg-[#1d1d1d] cursor-pointer" size="4" mt={"5"}>
-        프로젝트 보기
-      </Button>
-    </Flex>
+    <div className="flex-container">
+      <Flex className="container" direction="column" align="center" py={"9"}>
+        <Box my={"9"} />
+        <Text
+          as="div"
+          className={mediaText(ORIGIN_SIZE, MOBILE_SIZE)}
+          weight="bold"
+          mt="9"
+          align="center"
+        >
+          안녕하세요 ,
+        </Text>
+
+        <Flex
+          className={mediaText(ORIGIN_SIZE, MOBILE_SIZE)}
+          wrap={"wrap"}
+          align={"center"}
+          justify={"center"}
+        >
+          <TypingEffext text="프론트엔드 개발자" />
+          <Text as="div" weight="bold" align="center">
+            윤다빈 입니다
+          </Text>
+        </Flex>
+
+        <Text
+          className="relative inline-block"
+          as="div"
+          size="5"
+          align="center"
+          weight={"medium"}
+          mt={"4"}
+          mb={"2"}
+        >
+          <span className="relative z-10 ">
+            함께 하면 더 멀리 갈 수 있다고 믿는 개발자
+          </span>
+          <span className="absolute left-[0] top-[65%] h-[10px] w-full bg-[#fff5c9] z-0" />
+        </Text>
+
+        <Text as="div" color="gray" align="center" weight={"medium"}>
+          {data.subTitle1}
+        </Text>
+        <Text as="div" color="gray" align="center" weight={"medium"}>
+          {data.subTitle2}
+        </Text>
+
+        <Button className="bg-[#1d1d1d] cursor-pointer" size="4" mt={"5"}>
+          프로젝트 보기
+        </Button>
+      </Flex>
+    </div>
   );
 };
 

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -58,3 +58,20 @@ span.theme-text {
   transform: translateY(-8px);
   box-shadow: 0 4px 12px #ffe5d8;
 }
+
+/* 커서 깜빡임 애니메이션 */
+@keyframes blink {
+  0%,
+  100% {
+    border-color: black;
+  }
+  50% {
+    border-color: transparent;
+  }
+}
+
+.corsur-ani {
+  white-space: nowrap;
+  border-right: 2px solid black;
+  animation: blink 0.7s step-end infinite;
+}

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,0 +1,3 @@
+export const mediaText = (original: number, mobile: number): string => {
+  return `text-[${original}px] max-[600px]:text-[${mobile}px]`;
+};


### PR DESCRIPTION
## 변경 사항
- 타이핑 애니메이션 추가
- 타이틀 Text 반응형

## 이유
- 동적인 느낌을 위해 타이핑 애니메이션 추가
- 모바일 기기를 고려한 text 반응형

##  애로 사항
- 애니메이션 관련
   - TypingEffext을 처음에 훅으로 구현했다가 Header 컴포넌트 전체가 불필요하게 렌더링이 되길래 컴포넌트로 분리
- 반응형 관련
   - tailwind의 스타일 무시 이슈로 ... 현재 타이틀('안녕하세요~입니다') 부분만 반응형 적용. 이마저도 60px, 40px 이외엔 적용이 안되며 원인을 찾을 수 없음 ... tailwind을 사용하지 않고 기본 css로 돌아갈지 고민중