### PR TITLE
fix: hydration 에러 수정

### DIFF
--- a/src/page/home/Experience.tsx
+++ b/src/page/home/Experience.tsx
@@ -30,11 +30,12 @@ const Experience = () => {
             </Text>
 
             {item.achievements.map((item, i) => (
-              <Text key={i} fontSize={14} color="gray" mb={"1"}>
-                <Flex align={"center"}>
-                  <PiDotOutlineFill style={{ color: "#fbbf24" }} /> {item}
-                </Flex>
-              </Text>
+              <Flex align={"center"} key={i}>
+                <PiDotOutlineFill style={{ color: "#fbbf24" }} />
+                <Text fontSize={14} color="gray" mb={"1"}>
+                  {item}
+                </Text>
+              </Flex>
             ))}
           </WhiteCard>
         ))}


### PR DESCRIPTION
## 변경 사항
- hydration 에러 수정

## 이유
- <Text /> 태그 안에서 <Flex /> 사용 시 다음과 같은 에러 발생.
```
@react-refresh:228 In HTML, <div> cannot be a descendant of <p>.
This will cause a hydration error. 
```
Text가 <p>태그라서 div 같은 블록 요소를 넣는 것이 유효하지 않다는 판정하에 수정.

## 애로 사항
- 작성
